### PR TITLE
Add HTML support

### DIFF
--- a/hectane.php
+++ b/hectane.php
@@ -21,6 +21,19 @@ if(is_admin()) {
 
 // Only override the wp_mail() function if it doesn't exist
 if (!function_exists('wp_mail')) {
+
+    function hectane_isMessageHtml($message) {
+        $tStart = strpos($message, '<');
+        $tEnd = strpos($message, '>');
+        if($tStart === 0 && $tEnd > 1) {
+            $HMTL_ELEMENTS = array('!DOCTYPE'=>1, 'A'=>1, 'ABBR'=>1, 'ACRONYM'=>1, 'ADDRESS'=>1, 'APPLET'=>1, 'AREA'=>1, 'ARTICLE'=>1, 'ASIDE'=>1, 'AUDIO'=>1, 'B'=>1, 'BASE'=>1, 'BASEFONT'=>1, 'BDI'=>1, 'BDO'=>1, 'BIG'=>1, 'BLOCKQUOTE'=>1, 'BODY'=>1, 'BR'=>1, 'BUTTON'=>1, 'CANVAS'=>1, 'CAPTION'=>1, 'CENTER'=>1, 'CITE'=>1, 'CODE'=>1, 'COL'=>1, 'COLGROUP'=>1, 'DATALIST'=>1, 'DD'=>1, 'DEL'=>1, 'DETAILS'=>1, 'DFN'=>1, 'DIALOG'=>1, 'DIR'=>1, 'DIV'=>1, 'DL'=>1, 'DT'=>1, 'EM'=>1, 'EMBED'=>1, 'FIELDSET'=>1, 'FIGCAPTION'=>1, 'FIGURE'=>1, 'FONT'=>1, 'FOOTER'=>1, 'FORM'=>1, 'FRAME'=>1, 'FRAMESET'=>1, 'H1'=>1, 'HEAD'=>1, 'HEADER'=>1, 'HR'=>1, 'HTML'=>1, 'I'=>1, 'IFRAME'=>1, 'IMG'=>1, 'INPUT'=>1, 'INS'=>1, 'KBD'=>1, 'KEYGEN'=>1, 'LABEL'=>1, 'LEGEND'=>1, 'LI'=>1, 'LINK'=>1, 'MAIN'=>1, 'MAP'=>1, 'MARK'=>1, 'MENU'=>1, 'MENUITEM'=>1, 'META'=>1, 'METER'=>1, 'NAV'=>1, 'NOFRAMES'=>1, 'NOSCRIPT'=>1, 'OBJECT'=>1, 'OL'=>1, 'OPTGROUP'=>1, 'OPTION'=>1, 'OUTPUT'=>1, 'P'=>1, 'PARAM'=>1, 'PRE'=>1, 'PROGRESS'=>1, 'Q'=>1, 'RP'=>1, 'RT'=>1, 'RUBY'=>1, 'S'=>1, 'SAMP'=>1, 'SCRIPT'=>1, 'SECTION'=>1, 'SELECT'=>1, 'SMALL'=>1, 'SOURCE'=>1, 'SPAN'=>1, 'STRIKE'=>1, 'STRONG'=>1, 'STYLE'=>1, 'SUB'=>1, 'SUMMARY'=>1, 'SUP'=>1, 'TABLE'=>1, 'TBODY'=>1, 'TD'=>1, 'TEXTAREA'=>1, 'TFOOT'=>1, 'TH'=>1, 'THEAD'=>1, 'TIME'=>1, 'TITLE'=>1, 'TR'=>1, 'TRACK'=>1, 'TT'=>1, 'U'=>1, 'UL'=>1, 'VAR'=>1, 'VIDEO'=>1, 'WBR'=>1 );
+            $fullTag = substr($message, $tStart + 1, $tEnd - $tStart - 1);
+            $tag = strtoupper(explode(' ', $fullTag, 2)[0]);
+            return isset($HMTL_ELEMENTS[$tag]);
+        }
+        return false;
+    }
+
     /**
      * Override the default implementation of wp_mail().
      *
@@ -34,9 +47,14 @@ if (!function_exists('wp_mail')) {
         $email = array(
             'from' => sprintf('WordPress <wordpress@%s>', $_SERVER['SERVER_NAME']),
             'to' => is_array($to) ? $to : array($to),
-            'subject' => $subject,
-            'text' => $message,
+            'subject' => $subject
         );
+        if (hectane_isMessageHtml($message)) {
+            $email['html'] = $message;
+        }
+        else {
+            $email['text'] = $message;
+        }
         return HectaneAPI::instance()->send($email);
     }
 }

--- a/test.php
+++ b/test.php
@@ -1,0 +1,15 @@
+<?php
+// Poor man's testing. Run with:
+// $ php ./test.php
+
+function is_admin() { return false; }
+function plugin_dir_path($x) { return './'; }
+
+require_once 'hectane.php';
+
+// Test hectane_isMessageHtml
+echo (hectane_isMessageHtml("<html>hello</html>") ? "OK" : "FAILED") . "\n";
+echo (!hectane_isMessageHtml("<htl>hello</html>") ? "OK" : "FAILED") . "\n";
+echo (!hectane_isMessageHtml("Welcome my friend") ? "OK" : "FAILED") . "\n";
+echo (!hectane_isMessageHtml("V<html>hello</html>") ? "OK" : "FAILED") . "\n";
+echo (hectane_isMessageHtml("<table length=\"12\">hello</table>") ? "OK" : "FAILED") . "\n";


### PR DESCRIPTION
Detect that `$message` is HMTL (if it starts by an HTML element), set the `html` payload attribute if so.

A little hacky but reasonably I think.

Tested successfully with the Formidable plugin, but the solution is generic so it shouldn't matter which plugin is used.

Ref #3 
